### PR TITLE
New feature: Status

### DIFF
--- a/cat-posts.php
+++ b/cat-posts.php
@@ -543,13 +543,17 @@ class Widget extends \WP_Widget {
 			'order' => $sort_order
 		);
 
-                $valid_status = array('publish', 'future');
+                $valid_status = array('publish', 'future', 'both');
                 if ( isset($instance['status']) && in_array($instance['status'],$valid_status) ) {
                         $status = $instance['status'];
+			if ($status == 'both') {
+        			$args['post_status'] = array('publish', 'future');
+			} else {
+        			$args['post_status'] = $status;
+			}
                 } else {
-                        $status = 'publish';
+        		$args['post_status'] = 'publish';
                 }
-        $args['post_status'] = $status;
         
         if (isset($instance["num"])) 
             $args['showposts'] = (int) $instance["num"];
@@ -1079,6 +1083,7 @@ class Widget extends \WP_Widget {
                     <select id="<?php echo $this->get_field_id("status"); ?>" name="<?php echo $this->get_field_name("status"); ?>">
                         <option value="publish"<?php selected( $instance["status"], "publish" ); ?>><?php _e('Published','category-posts')?></option>
                         <option value="future"<?php selected( $instance["status"], "future" ); ?>><?php _e('Scheduled','category-posts')?></option>
+                        <option value="both"<?php selected( $instance["status"], "both" ); ?>><?php _e('Published & Scheduled','category-posts')?></option>
                     </select>
                 </label>
             </p>

--- a/cat-posts.php
+++ b/cat-posts.php
@@ -542,6 +542,14 @@ class Widget extends \WP_Widget {
 			'orderby' => $sort_by,
 			'order' => $sort_order
 		);
+
+                $valid_status = array('publish', 'future', 'any');
+                if ( isset($instance['status']) && in_array($instance['status'],$valid_status) ) {
+                        $status = $instance['status'];
+                } else {
+                        $status = 'publish';
+                }
+        $args['post_status'] = $status;
         
         if (isset($instance["num"])) 
             $args['showposts'] = (int) $instance["num"];
@@ -1023,6 +1031,7 @@ class Widget extends \WP_Widget {
 			'num'                  => get_option('posts_per_page'),
 			'offset'               => 1,
 			'sort_by'              => '',
+			'status'               => '',
 			'asc_sort_order'       => '',
 			'exclude_current_post' => '',
 			'hideNoThumb'          => '',
@@ -1032,6 +1041,7 @@ class Widget extends \WP_Widget {
 		$num                  = $instance['num'];
 		$offset               = $instance['offset'];
 		$sort_by              = $instance['sort_by'];
+		$status               = $instance['status'];
 		$asc_sort_order       = $instance['asc_sort_order'];
 		$exclude_current_post = $instance['exclude_current_post'];
 		$hideNoThumb          = $instance['hideNoThumb'];
@@ -1061,6 +1071,16 @@ class Widget extends \WP_Widget {
                 <label for="<?php echo $this->get_field_id("offset"); ?>">
                     <?php _e('Start with post','category-posts'); ?>:
                     <input style="text-align: center; width: 30%;" id="<?php echo $this->get_field_id("offset"); ?>" name="<?php echo $this->get_field_name("offset"); ?>" type="number" min="1" value="<?php echo absint($instance["offset"]); ?>" />
+                </label>
+            </p>
+            <p>
+                <label for="<?php echo $this->get_field_id("status"); ?>">
+                    <?php _e('Status','category-posts'); ?>:
+                    <select id="<?php echo $this->get_field_id("status"); ?>" name="<?php echo $this->get_field_name("status"); ?>">
+                        <option value="publish"<?php selected( $instance["status"], "publish" ); ?>><?php _e('Published','category-posts')?></option>
+                        <option value="future"<?php selected( $instance["status"], "future" ); ?>><?php _e('Scheduled','category-posts')?></option>
+                        <option value="any"<?php selected( $instance["status"], "any" ); ?>><?php _e('Any','category-posts')?></option>
+                    </select>
                 </label>
             </p>
             <p>
@@ -1637,6 +1657,7 @@ function default_settings()  {
 				'num'                             => get_option('posts_per_page'),
 				'offset'                          => 1,
 				'sort_by'                         => 'date',
+				'status'                          => 'publish',
 				'asc_sort_order'                  => false,
 				'exclude_current_post'            => false,
 				'hideNoThumb'                     => false,

--- a/cat-posts.php
+++ b/cat-posts.php
@@ -543,7 +543,7 @@ class Widget extends \WP_Widget {
 			'order' => $sort_order
 		);
 
-                $valid_status = array('publish', 'future', 'any');
+                $valid_status = array('publish', 'future');
                 if ( isset($instance['status']) && in_array($instance['status'],$valid_status) ) {
                         $status = $instance['status'];
                 } else {
@@ -1079,7 +1079,6 @@ class Widget extends \WP_Widget {
                     <select id="<?php echo $this->get_field_id("status"); ?>" name="<?php echo $this->get_field_name("status"); ?>">
                         <option value="publish"<?php selected( $instance["status"], "publish" ); ?>><?php _e('Published','category-posts')?></option>
                         <option value="future"<?php selected( $instance["status"], "future" ); ?>><?php _e('Scheduled','category-posts')?></option>
-                        <option value="any"<?php selected( $instance["status"], "any" ); ?>><?php _e('Any','category-posts')?></option>
                     </select>
                 </label>
             </p>


### PR DESCRIPTION
Based on the 'sort_by' code I wrote a small feature addition for cat-posts which would allow the display of published or scheduled posts  or both published and scheduled by allowing users to select the post_status in the cat-post configurator.

Originally I had added an option for "any" but I'm not sure that would be very useful.  Any would be equivalent to: 'post_status' => array('publish', 'pending', 'draft', 'auto-draft', 'future', 'private', 'inherit', 'trash')    
This just seems like too much stuff to be useful.

The ability to have two short code instances on one page meant for me the ability to have one instance which showed the current posts filtered as I like and another with a look ahead filtered slightly differently.

I hope you find this useful.